### PR TITLE
Increase docker shared memory

### DIFF
--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,4 +1,5 @@
 docker run --name isaac-sim-oige --entrypoint bash -it -d --gpus all -e "ACCEPT_EULA=Y" --rm --network=host \
+--shm-size=1g \
 -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json \
 -v /etc/vulkan/implicit_layer.d/nvidia_layers.json:/etc/vulkan/implicit_layer.d/nvidia_layers.json \
 -v ${PWD}:/workspace/omniisaacgymenvs \

--- a/docker/run_docker_viewer.sh
+++ b/docker/run_docker_viewer.sh
@@ -1,5 +1,6 @@
 xhost +
 docker run --name isaac-sim-oige --entrypoint bash -it -d --gpus all -e "ACCEPT_EULA=Y" --rm --network=host \
+--shm-size=1g \
 -v $HOME/.Xauthority:/root/.Xauthority \
 -e DISPLAY \
 -v /etc/vulkan/icd.d/nvidia_icd.json:/etc/vulkan/icd.d/nvidia_icd.json \


### PR DESCRIPTION
This fixes an error when running with multiple GPUs from a docker container. This increases the shared memory given to the docker container to 1 GB by default. 

Tested with the following:
```
# run container
cd OmniIsaacGymEnvs
docker/run_docker_viewer.sh

# inside container, run single GPU (Headless)
/isaac-sim/python.sh scripts/rlgames_train.py task=Ant headless=True

# inside container, run with multi_gpu=True
/isaac-sim/python.sh -m torch.distributed.run --nnodes=1 --nproc_per_node=4 scripts/rlgames_train.py headless=True task=Ant multi_gpu=True
```